### PR TITLE
Merge label-refactor branch and refactor the annotations into kubernetes decorator

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -75,6 +75,9 @@ CLIENT_CACHE_MAX_TASKDATASTORE_COUNT = from_conf(
 S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 
+# Set ServerSideEncryption for S3 uploads
+S3_SERVER_SIDE_ENCRYPTION = from_conf("S3_SERVER_SIDE_ENCRYPTION")
+
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution
 # though as this may increase failures. Note that this is the number of *retries*

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -59,8 +59,8 @@ def from_conf(name, default=None, validate_fn=None):
     validate_fn should accept (name, value).
     If the value validates, return None, else raise an MetaflowException.
     """
-    env_name = "METAFLOW_%s" % name
     is_default = True
+    env_name = "METAFLOW_%s" % name
     value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))
     if validate_fn and value is not None:
         validate_fn(env_name, value)

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -156,13 +156,16 @@ class MetaflowPackage(object):
         buf.write(json.dumps(env).encode("utf-8"))
         buf.seek(0)
         info.size = len(buf.getvalue())
+        # Setting this default to Dec 3, 2019
+        info.mtime = 1575360000
         tar.addfile(info, buf)
 
     def _make(self):
         def no_mtime(tarinfo):
             # a modification time change should not change the hash of
             # the package. Only content modifications will.
-            tarinfo.mtime = 0
+            # Setting this default to Dec 3, 2019
+            tarinfo.mtime = 1575360000
             return tarinfo
 
         buf = BytesIO()

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -277,7 +277,7 @@ class Airflow(object):
         env_deco = [deco for deco in node.decorators if deco.name == "environment"]
         env = {}
         if env_deco:
-            env = env_deco[0].attributes["vars"]
+            env = env_deco[0].attributes["vars"].copy()
 
         # The below if/else block handles "input paths".
         # Input Paths help manage dataflow across the graph.

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -17,6 +17,24 @@ class ArgoClient(object):
         self._group = "argoproj.io"
         self._version = "v1alpha1"
 
+    def get_workflow(self, name):
+        client = self._client.get()
+        try:
+            workflow = client.CustomObjectsApi().get_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflows",
+                name=name,
+            )
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                return None
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+        return workflow
+
     def get_workflow_template(self, name):
         client = self._client.get()
         try:
@@ -80,6 +98,54 @@ class ArgoClient(object):
                 plural="workflowtemplates",
                 body=workflow_template,
                 name=name,
+            )
+        except client.rest.ApiException as e:
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+    def suspend_workflow(self, name):
+        workflow = self.get_workflow(name)
+        if workflow is None:
+            raise ArgoClientException("Execution argo-%s was not found" % name)
+
+        if workflow["status"]["finishedAt"] is not None:
+            raise ArgoClientException(
+                "Cannot suspend an execution that has already finished."
+            )
+        if workflow["spec"].get("suspend") is True:
+            raise ArgoClientException("Execution has already been suspended.")
+
+        body = {"spec": workflow["spec"]}
+        body["spec"]["suspend"] = True
+        return self._patch_workflow(name, body)
+
+    def unsuspend_workflow(self, name):
+        workflow = self.get_workflow(name)
+        if workflow is None:
+            raise ArgoClientException("Execution argo-%s was not found" % name)
+
+        if workflow["status"]["finishedAt"] is not None:
+            raise ArgoClientException(
+                "Cannot unsuspend an execution that has already finished."
+            )
+        if not workflow["spec"].get("suspend", False):
+            raise ArgoClientException("Execution is already proceeding.")
+
+        body = {"spec": workflow["spec"]}
+        body["spec"]["suspend"] = False
+        return self._patch_workflow(name, body)
+
+    def _patch_workflow(self, name, body):
+        client = self._client.get()
+        try:
+            return client.CustomObjectsApi().patch_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflows",
+                name=name,
+                body=body,
             )
         except client.rest.ApiException as e:
             raise ArgoClientException(

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -104,6 +104,92 @@ class ArgoClient(object):
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
 
+    def delete_cronworkflow(self, name):
+        """
+        Issues an API call for deleting a cronworkflow
+
+        Returns either the successful API response, or None in case the resource was not found.
+        """
+        client = self._client.get()
+
+        try:
+            return client.CustomObjectsApi().delete_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="cronworkflows",
+                name=name,
+            )
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                return None
+            else:
+                raise ArgoClientException(
+                    json.loads(e.body)["message"] if e.body is not None else e.reason
+                )
+
+    def delete_workflow_template(self, name):
+        """
+        Issues an API call for deleting a cronworkflow
+
+        Returns either the successful API response, or None in case the resource was not found.
+        """
+        client = self._client.get()
+
+        try:
+            return client.CustomObjectsApi().delete_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflowtemplates",
+                name=name,
+            )
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                return None
+            else:
+                raise ArgoClientException(
+                    json.loads(e.body)["message"] if e.body is not None else e.reason
+                )
+
+    def terminate_workflow(self, run_id):
+        client = self._client.get()
+        try:
+            workflow = client.CustomObjectsApi().get_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflows",
+                name=run_id,
+            )
+        except client.rest.ApiException as e:
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+        if workflow["status"]["finishedAt"] is not None:
+            raise ArgoClientException(
+                "Cannot terminate an execution that has already finished."
+            )
+        if workflow["spec"].get("shutdown") == "Terminate":
+            raise ArgoClientException("Execution has already been terminated.")
+
+        try:
+            body = {"spec": workflow["spec"]}
+            body["spec"]["shutdown"] = "Terminate"
+            return client.CustomObjectsApi().patch_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflows",
+                name=run_id,
+                body=body,
+            )
+        except client.rest.ApiException as e:
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
     def suspend_workflow(self, name):
         workflow = self.get_workflow(name)
         if workflow is None:
@@ -273,8 +359,6 @@ class ArgoClient(object):
         except client.rest.ApiException as e:
             # Sensor does not exist and we want to add one
             if e.status == 404:
-                if sensor.get("kind") is None:
-                    return
                 try:
                     return client.CustomObjectsApi().create_namespaced_custom_object(
                         group=self._group,
@@ -293,20 +377,6 @@ class ArgoClient(object):
                 raise ArgoClientException(
                     json.loads(e.body)["message"] if e.body is not None else e.reason
                 )
-        # Since sensors occupy real resources, delete existing sensor if needed
-        if sensor.get("kind") is None:
-            try:
-                return client.CustomObjectsApi().delete_namespaced_custom_object(
-                    group=self._group,
-                    version=self._version,
-                    namespace=self._namespace,
-                    plural="sensors",
-                    name=name,
-                )
-            except client.rest.ApiException as e:
-                raise ArgoClientException(
-                    json.loads(e.body)["message"] if e.body is not None else e.reason
-                )
         try:
             return client.CustomObjectsApi().replace_namespaced_custom_object(
                 group=self._group,
@@ -317,6 +387,29 @@ class ArgoClient(object):
                 name=name,
             )
         except client.rest.ApiException as e:
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+    def delete_sensor(self, name):
+        """
+        Issues an API call for deleting a sensor
+
+        Returns either the successful API response, or None in case the resource was not found.
+        """
+        client = self._client.get()
+
+        try:
+            return client.CustomObjectsApi().delete_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="sensors",
+                name=name,
+            )
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                return None
             raise ArgoClientException(
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -444,9 +444,13 @@ class ArgoWorkflows(object):
             # Argo Events sensors. There is a slight possibility of name collision
             # but quite unlikely for us to worry about at this point.
             event["sanitized_name"] = event["name"]
-            if any([x in event["name"] for x in [".", "-"]]):
+            if any([x in event["name"] for x in [".", "-", "@", "+"]]):
                 event["sanitized_name"] = "%s_%s" % (
-                    event["name"].replace(".", "").replace("-", ""),
+                    event["name"]
+                    .replace(".", "")
+                    .replace("-", "")
+                    .replace("@", "")
+                    .replace("+", ""),
                     to_unicode(
                         base64.b32encode(sha1(to_bytes(event["name"])).digest())
                     )[:4].lower(),

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -654,7 +654,11 @@ class ArgoWorkflows(object):
                 )
                 # Set common pod metadata.
                 .pod_metadata(
-                    Metadata().annotations(annotations).labels(self.kubernetes_labels)
+                    Metadata()
+                    .labels(self.kubernetes_labels)
+                    .label("app.kubernetes.io/name", "metaflow-task")
+                    .label("app.kubernetes.io/part-of", "metaflow")
+                    .annotations(annotations)
                 )
                 # Set the entrypoint to flow name
                 .entrypoint(self.flow.name)
@@ -1553,9 +1557,9 @@ class ArgoWorkflows(object):
                 ObjectMeta()
                 .name(self.name.replace(".", "-"))
                 .namespace(KUBERNETES_NAMESPACE)
+                .labels(self.kubernetes_labels)
                 .label("app.kubernetes.io/name", "metaflow-sensor")
                 .label("app.kubernetes.io/part-of", "metaflow")
-                .labels(self.kubernetes_labels)
                 .annotations(annotations)
             )
             .spec(

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -213,6 +213,7 @@ class ArgoWorkflows(object):
                 )
             )
 
+    @staticmethod
     def suspend(name):
         client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
 

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -444,18 +444,16 @@ class ArgoWorkflows(object):
             # Assign a sanitized name since we need this at many places to please
             # Argo Events sensors. There is a slight possibility of name collision
             # but quite unlikely for us to worry about at this point.
-            event["sanitized_name"] = event["name"]
-            if any([x in event["name"] for x in [".", "-", "@", "+"]]):
-                event["sanitized_name"] = "%s_%s" % (
-                    event["name"]
-                    .replace(".", "")
-                    .replace("-", "")
-                    .replace("@", "")
-                    .replace("+", ""),
-                    to_unicode(
-                        base64.b32encode(sha1(to_bytes(event["name"])).digest())
-                    )[:4].lower(),
-                )
+            event["sanitized_name"] = "%s_%s" % (
+                event["name"]
+                .replace(".", "")
+                .replace("-", "")
+                .replace("@", "")
+                .replace("+", ""),
+                to_unicode(base64.b32encode(sha1(to_bytes(event["name"])).digest()))[
+                    :4
+                ].lower(),
+            )
         return triggers, options
 
     def _compile_workflow_template(self):
@@ -938,10 +936,8 @@ class ArgoWorkflows(object):
                     ]
                     + [
                         # Parameter names can be hyphenated, hence we use
-                        # {{foo.bar['param_name']}}. We quote the value to
-                        # make sure whitespaces are properly handled since
-                        # Argo Events wouldn't do that for us.
-                        "--%s='{{workflow.parameters.%s}}'"
+                        # {{foo.bar['param_name']}}.
+                        "--%s={{workflow.parameters.%s}}"
                         % (parameter["name"], parameter["name"])
                         for parameter in self.parameters.values()
                     ]
@@ -1274,12 +1270,13 @@ class ArgoWorkflows(object):
                                 + ARGO_WORKFLOWS_KUBERNETES_SECRETS.split(",")
                                 if k
                             ],
-                            # Assign a volume point to pass state to the next task.
                             volume_mounts=[
+                                # Assign a volume mount to pass state to the next task.
                                 kubernetes_sdk.V1VolumeMount(
                                     name="out", mount_path="/mnt/out"
                                 )
                             ]
+                            # Support tmpfs.
                             + (
                                 [
                                     kubernetes_sdk.V1VolumeMount(
@@ -1290,6 +1287,7 @@ class ArgoWorkflows(object):
                                 if tmpfs_enabled
                                 else []
                             )
+                            # Support persistent volume claims.
                             + (
                                 [
                                     kubernetes_sdk.V1VolumeMount(

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -176,6 +176,43 @@ class ArgoWorkflows(object):
         return name.replace("_", "-")
 
     @staticmethod
+    def delete(name):
+        client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
+
+        # Always try to delete the schedule. Failure in deleting the schedule should not
+        # be treated as an error, due to any of the following reasons
+        # - there might not have been a schedule, or it was deleted by some other means
+        # - retaining these resources should have no consequences as long as the workflow deletion succeeds.
+        # - regarding cost and compute, the significant resources are part of the workflow teardown, not the schedule.
+        schedule_deleted = client.delete_cronworkflow(name)
+
+        # The workflow might have sensors attached to it, which consume actual resources.
+        # Try to delete these as well.
+        sensor_deleted = client.delete_sensor(name)
+
+        # After cleaning up related resources, delete the workflow in question.
+        # Failure in deleting is treated as critical and will be made visible to the user
+        # for further action.
+        workflow_deleted = client.delete_workflow_template(name)
+        if workflow_deleted is None:
+            raise ArgoWorkflowsException(
+                "The workflow *%s* doesn't exist on Argo Workflows." % name
+            )
+
+        return schedule_deleted, sensor_deleted, workflow_deleted
+
+    @staticmethod
+    def terminate(flow_name, name):
+        client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
+
+        response = client.terminate_workflow(name)
+        if response is None:
+            raise ArgoWorkflowsException(
+                "No execution found for {flow_name}/{run_id} in Argo Workflows.".format(
+                    flow_name=flow_name, run_id=name
+                )
+            )
+
     def suspend(name):
         client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
 
@@ -247,16 +284,20 @@ class ArgoWorkflows(object):
 
     def schedule(self):
         try:
-            ArgoClient(namespace=KUBERNETES_NAMESPACE).schedule_workflow_template(
+            argo_client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
+            argo_client.schedule_workflow_template(
                 self.name, self._schedule, self._timezone
             )
             # Register sensor. Unfortunately, Argo Events Sensor names don't allow for
             # dots (sensors run into an error) which rules out self.name :(
             # Metaflow will overwrite any existing sensor.
-            ArgoClient(namespace=KUBERNETES_NAMESPACE).register_sensor(
-                self.name.replace(".", "-"),
-                self._sensor.to_json() if self._sensor else {},
-            )
+            sensor_name = self.name.replace(".", "-")
+            if self._sensor:
+                argo_client.register_sensor(sensor_name, self._sensor.to_json())
+            else:
+                # Since sensors occupy real resources, delete existing sensor if needed
+                # Deregister sensors that might have existed before this deployment
+                argo_client.delete_sensor(sensor_name)
         except Exception as e:
             raise ArgoWorkflowsSchedulingException(str(e))
 

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -38,6 +38,7 @@ from metaflow.metaflow_config import (
     S3_ENDPOINT_URL,
     SERVICE_HEADERS,
     SERVICE_INTERNAL_URL,
+    S3_SERVER_SIDE_ENCRYPTION,
 )
 from metaflow.mflog import BASH_SAVE_LOGS, bash_capture_logs, export_mflog_env_vars
 from metaflow.parameters import deploy_time_eval
@@ -1104,6 +1105,10 @@ class ArgoWorkflows(object):
                         "METAFLOW_ARGO_EVENT_PAYLOAD_%s_%s"
                         % (event["type"], event["sanitized_name"])
                     ] = ("{{workflow.parameters.%s}}" % event["sanitized_name"])
+
+            # Map S3 upload headers to environment variables
+            if S3_SERVER_SIDE_ENCRYPTION is not None:
+                env["METAFLOW_S3_SERVER_SIDE_ENCRYPTION"] = S3_SERVER_SIDE_ENCRYPTION
 
             metaflow_version = self.environment.get_environment_info()
             metaflow_version["flow_name"] = self.graph.name

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -37,6 +37,10 @@ class IncorrectProductionToken(MetaflowException):
     headline = "Incorrect production token"
 
 
+class RunIdMismatch(MetaflowException):
+    headline = "Run ID mismatch"
+
+
 class IncorrectMetadataServiceVersion(MetaflowException):
     headline = "Incorrect version for metaflow service"
 
@@ -335,14 +339,7 @@ def resolve_workflow_name(obj, name):
             workflow_name = "%s-%s" % (workflow_name[:242], name_hash)
             obj._is_workflow_name_modified = True
         if not VALID_NAME.search(workflow_name):
-            workflow_name = (
-                re.compile(r"^[^A-Za-z0-9]+")
-                .sub("", workflow_name)
-                .replace("_", "")
-                .replace("@", "")
-                .replace("+", "")
-                .lower()
-            )
+            workflow_name = sanitize_for_argo(workflow_name)
             obj._is_workflow_name_modified = True
     else:
         if name and not VALID_NAME.search(name):
@@ -367,14 +364,7 @@ def resolve_workflow_name(obj, name):
             raise ArgoWorkflowsNameTooLong(msg)
 
         if not VALID_NAME.search(workflow_name):
-            workflow_name = (
-                re.compile(r"^[^A-Za-z0-9]+")
-                .sub("", workflow_name)
-                .replace("_", "")
-                .replace("@", "")
-                .replace("+", "")
-                .lower()
-            )
+            workflow_name = sanitize_for_argo(workflow_name)
             obj._is_workflow_name_modified = True
 
     return workflow_name, token_prefix.lower(), is_project
@@ -600,3 +590,215 @@ def trigger(obj, run_id_file=None, **kwargs):
             "See the run in the UI at %s" % run_url,
             bold=True,
         )
+
+
+@argo_workflows.command(help="Suspend flow execution on Argo Workflows.")
+@click.option(
+    "--authorize",
+    default=None,
+    type=str,
+    help="Authorize the suspension with a production token",
+)
+@click.argument("run-id", required=True, type=str)
+@click.pass_obj
+def suspend(obj, run_id, authorize=None):
+    def _token_instructions(flow_name, prev_user):
+        obj.echo(
+            "There is an existing version of *%s* on Argo Workflows which was "
+            "deployed by the user *%s*." % (flow_name, prev_user)
+        )
+        obj.echo(
+            "To suspend this flow, you need to use the same production token that they used."
+        )
+        obj.echo(
+            "Please reach out to them to get the token. Once you have it, call "
+            "this command:"
+        )
+        obj.echo("    argo-workflows suspend RUN_ID --authorize MY_TOKEN", fg="green")
+        obj.echo(
+            'See "Organizing Results" at docs.metaflow.org for more information '
+            "about production tokens."
+        )
+
+    validate_run_id(
+        obj.workflow_name, obj.token_prefix, authorize, run_id, _token_instructions
+    )
+
+    # Trim prefix from run_id
+    name = run_id[5:]
+
+    workflow_suspended = ArgoWorkflows.suspend(name)
+
+    if workflow_suspended:
+        obj.echo("Suspended execution of *%s*" % run_id)
+
+
+@argo_workflows.command(help="Unsuspend flow execution on Argo Workflows.")
+@click.option(
+    "--authorize",
+    default=None,
+    type=str,
+    help="Authorize the unsuspend with a production token",
+)
+@click.argument("run-id", required=True, type=str)
+@click.pass_obj
+def unsuspend(obj, run_id, authorize=None):
+    def _token_instructions(flow_name, prev_user):
+        obj.echo(
+            "There is an existing version of *%s* on Argo Workflows which was "
+            "deployed by the user *%s*." % (flow_name, prev_user)
+        )
+        obj.echo(
+            "To unsuspend this flow, you need to use the same production token that they used."
+        )
+        obj.echo(
+            "Please reach out to them to get the token. Once you have it, call "
+            "this command:"
+        )
+        obj.echo(
+            "    argo-workflows unsuspend RUN_ID --authorize MY_TOKEN",
+            fg="green",
+        )
+        obj.echo(
+            'See "Organizing Results" at docs.metaflow.org for more information '
+            "about production tokens."
+        )
+
+    validate_run_id(
+        obj.workflow_name, obj.token_prefix, authorize, run_id, _token_instructions
+    )
+
+    # Trim prefix from run_id
+    name = run_id[5:]
+
+    workflow_suspended = ArgoWorkflows.unsuspend(name)
+
+    if workflow_suspended:
+        obj.echo("Unsuspended execution of *%s*" % run_id)
+
+
+def validate_token(name, token_prefix, authorize, instructions_fn=None):
+    """
+    Validate that the production token matches that of the deployed flow.
+    In case both the user and token do not match, raises an error.
+    Optionally outputs instructions on token usage via the provided instruction_fn(flow_name, prev_user)
+    """
+    # TODO: Unify this with the existing resolve_token implementation.
+
+    # 1) retrieve the previous deployment, if one exists
+    workflow = ArgoWorkflows.get_existing_deployment(name)
+    if workflow is None:
+        prev_token = None
+    else:
+        prev_user, prev_token = workflow
+
+    # 2) authorize this deployment
+    if prev_token is not None:
+        if authorize is None:
+            authorize = load_token(token_prefix)
+        elif authorize.startswith("production:"):
+            authorize = authorize[11:]
+
+        # we allow the user who deployed the previous version to re-deploy,
+        # even if they don't have the token
+        # NOTE: The username is visible in multiple sources, and can be set by the user.
+        # Should we consider being stricter here?
+        if prev_user != get_username() and authorize != prev_token:
+            if instructions_fn:
+                instructions_fn(flow_name=name, prev_user=prev_user)
+            raise IncorrectProductionToken(
+                "Try again with the correct production token."
+            )
+
+    # 3) all validations passed, store the previous token for future use
+    token = prev_token
+
+    store_token(token_prefix, token)
+    return True
+
+
+def validate_run_id(
+    workflow_name, token_prefix, authorize, run_id, instructions_fn=None
+):
+    """
+    Validates that a run_id adheres to the Argo Workflows naming rules, and
+    that it belongs to the current flow (accounting for project branch as well).
+    """
+    # Verify that user is trying to change an Argo workflow
+    if not run_id.startswith("argo-"):
+        raise RunIdMismatch(
+            "Run IDs for flows executed through Argo Workflows begin with 'argo-'"
+        )
+
+    # Verify that run_id belongs to the Flow, and that branches match
+    name = run_id[5:]
+    workflow = ArgoWorkflows.get_execution(name)
+    if workflow is None:
+        raise MetaflowException("Could not find workflow *%s* on Argo Workflows" % name)
+
+    owner, token, flow_name, branch_name, project_name = workflow
+
+    # Verify we are operating on the correct Flow file compared to the running one.
+    # Without this check, using --name could be used to run commands for arbitrary run_id's, disregarding the Flow in the file.
+    if current.flow_name != flow_name:
+        raise RunIdMismatch(
+            "The workflow with the run_id *%s* belongs to the flow *%s*, not for the flow *%s*."
+            % (run_id, flow_name, current.flow_name)
+        )
+
+    if project_name is not None:
+        # Verify we are operating on the correct project.
+        # Perform match with separators to avoid substrings matching
+        # e.g. 'test_proj' and 'test_project' should count as a mismatch.
+        project_part = "%s." % sanitize_for_argo(project_name)
+        if (
+            current.get("project_name") != project_name
+            and project_part not in workflow_name
+        ):
+            raise RunIdMismatch(
+                "The workflow belongs to the project *%s*. "
+                "Please use the project decorator or --name to target the correct project"
+                % project_name
+            )
+
+        # Verify we are operating on the correct branch.
+        # Perform match with separators to avoid substrings matching.
+        # e.g. 'user.tes' and 'user.test' should count as a mismatch.
+        branch_part = ".%s." % sanitize_for_argo(branch_name)
+        if (
+            current.get("branch_name") != branch_name
+            and branch_part not in workflow_name
+        ):
+            raise RunIdMismatch(
+                "The workflow belongs to the branch *%s*. "
+                "Please use --branch, --production or --name to target the correct branch"
+                % branch_name
+            )
+
+    # Verify that the production tokens match. We do not want to cache the token that was used though,
+    # as the operations that require run_id validation can target runs not authored from the local environment
+    if authorize is None:
+        authorize = load_token(token_prefix)
+    elif authorize.startswith("production:"):
+        authorize = authorize[11:]
+
+    if owner != get_username() and authorize != token:
+        if instructions_fn:
+            instructions_fn(flow_name=name, prev_user=owner)
+        raise IncorrectProductionToken("Try again with the correct production token.")
+
+    return True
+
+
+def sanitize_for_argo(text):
+    """
+    Sanitizes a string so it does not contain characters that are not permitted in Argo Workflow resource names.
+    """
+    return (
+        re.compile(r"^[^A-Za-z0-9]+")
+        .sub("", text)
+        .replace("_", "")
+        .replace("@", "")
+        .replace("+", "")
+        .lower()
+    )

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -326,6 +326,8 @@ def resolve_workflow_name(obj, name):
         # by default. Also, while project and branch allow for underscores, Argo
         # Workflows doesn't (DNS Subdomain names as defined in RFC 1123) - so we will
         # remove any underscores as well as convert the name to lower case.
+        # Also remove + and @ as not allowed characters, which can be part of the
+        # project branch due to using email addresses as user names.
         if len(workflow_name) > 253:
             name_hash = to_unicode(
                 base64.b32encode(sha1(to_bytes(workflow_name)).digest())
@@ -337,6 +339,8 @@ def resolve_workflow_name(obj, name):
                 re.compile(r"^[^A-Za-z0-9]+")
                 .sub("", workflow_name)
                 .replace("_", "")
+                .replace("@", "")
+                .replace("+", "")
                 .lower()
             )
             obj._is_workflow_name_modified = True
@@ -367,6 +371,8 @@ def resolve_workflow_name(obj, name):
                 re.compile(r"^[^A-Za-z0-9]+")
                 .sub("", workflow_name)
                 .replace("_", "")
+                .replace("@", "")
+                .replace("+", "")
                 .lower()
             )
             obj._is_workflow_name_modified = True

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -21,6 +21,7 @@ from metaflow.metaflow_config import (
     S3_ENDPOINT_URL,
     DEFAULT_SECRETS_BACKEND_TYPE,
     AWS_SECRETS_MANAGER_DEFAULT_REGION,
+    S3_SERVER_SIDE_ENCRYPTION,
 )
 from metaflow.mflog import (
     export_mflog_env_vars,
@@ -262,6 +263,11 @@ class Batch(object):
 
         if tmpfs_enabled and tmpfs_tempdir:
             job.environment_variable("METAFLOW_TEMPDIR", tmpfs_path)
+
+        if S3_SERVER_SIDE_ENCRYPTION is not None:
+            job.environment_variable(
+                "METAFLOW_S3_SERVER_SIDE_ENCRYPTION", S3_SERVER_SIDE_ENCRYPTION
+            )
 
         # Skip setting METAFLOW_DATASTORE_SYSROOT_LOCAL because metadata sync between the local user
         # instance and the remote AWS Batch instance assumes metadata is stored in DATASTORE_LOCAL_DIR

--- a/metaflow/plugins/aws/step_functions/event_bridge_client.py
+++ b/metaflow/plugins/aws/step_functions/event_bridge_client.py
@@ -60,6 +60,19 @@ class EventBridgeClient(object):
             ],
         )
 
+    def delete(self):
+        try:
+            response = self._client.remove_targets(
+                Rule=self.name,
+                Ids=[self.name],
+            )
+            if response.get("FailedEntryCount", 0) > 0:
+                raise RuntimeError("Failed to remove targets from rule %s" % self.name)
+            return self._client.delete_rule(Name=self.name)
+        except self._client.exceptions.ResourceNotFoundException:
+            # Ignore if the rule does not exist.
+            return None
+
 
 def format(name):
     # AWS Event Bridge has a limit of 64 chars for rule names.

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -159,6 +159,20 @@ class StepFunctions(object):
             raise StepFunctionsSchedulingException(repr(e))
 
     @classmethod
+    def delete(cls, name):
+        # Always attempt to delete the event bridge rule.
+        schedule_deleted = EventBridgeClient(name).delete()
+
+        sfn_deleted = StepFunctionsClient().delete(name)
+
+        if sfn_deleted is None:
+            raise StepFunctionsException(
+                "The workflow *%s* doesn't exist on AWS Step Functions." % name
+            )
+
+        return schedule_deleted, sfn_deleted
+
+    @classmethod
     def trigger(cls, name, parameters):
         try:
             state_machine = StepFunctionsClient().get(name)

--- a/metaflow/plugins/aws/step_functions/step_functions_client.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_client.py
@@ -117,3 +117,11 @@ class StepFunctionsClient(object):
             if state_machine:
                 return state_machine["stateMachineArn"]
             return None
+
+    def delete(self, name):
+        state_machine_arn = self.get_state_machine_arn(name)
+        if state_machine_arn is None:
+            return None
+        return self._client.delete_state_machine(
+            stateMachineArn=state_machine_arn,
+        )

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -17,6 +17,7 @@ from metaflow.metaflow_config import (
     DATATOOLS_S3ROOT,
     S3_RETRY_COUNT,
     S3_TRANSIENT_RETRY_COUNT,
+    S3_SERVER_SIDE_ENCRYPTION,
     TEMPDIR,
 )
 from metaflow.util import (
@@ -83,9 +84,10 @@ S3PutObject = namedtuple_with_defaults(
         ("value", Optional[PutValue]),
         ("path", Optional[str]),
         ("content_type", Optional[str]),
+        ("encryption", Optional[str]),
         ("metadata", Optional[Dict[str, str]]),
     ],
-    defaults=(None, None, None, None),
+    defaults=(None, None, None, None, None),
 )
 S3PutObject.__module__ = __name__
 
@@ -142,6 +144,7 @@ class S3Object(object):
         metadata: Optional[Dict[str, str]] = None,
         range_info: Optional[RangeInfo] = None,
         last_modified: int = None,
+        encryption: Optional[str] = None,
     ):
         # all fields of S3Object should return a unicode object
         prefix, url, path = map(ensure_unicode, (prefix, url, path))
@@ -175,6 +178,8 @@ class S3Object(object):
         else:
             self._key = url[len(prefix.rstrip("/")) + 1 :].rstrip("/")
             self._prefix = prefix
+
+        self._encryption = encryption
 
     @property
     def exists(self) -> bool:
@@ -321,6 +326,7 @@ class S3Object(object):
             self._content_type is not None
             or self._metadata is not None
             or self._range_info is not None
+            or self._encryption is not None
         )
 
     @property
@@ -347,6 +353,18 @@ class S3Object(object):
             Content type or None if the content type is undefined.
         """
         return self._content_type
+
+    @property
+    def encryption(self) -> Optional[str]:
+        """
+        Returns the encryption type of the S3 object or None if it is not defined.
+
+        Returns
+        -------
+        str
+            Server-side-encryption type or None if parameter is not set.
+        """
+        return self._encryption
 
     @property
     def range_info(self) -> Optional[RangeInfo]:
@@ -486,6 +504,7 @@ class S3(object):
         prefix: Optional[str] = None,
         run: Optional[Union[FlowSpec, "Run"]] = None,
         s3root: Optional[str] = None,
+        encryption: Optional[str] = S3_SERVER_SIDE_ENCRYPTION,
         **kwargs
     ):
         if not boto_found:
@@ -539,6 +558,7 @@ class S3(object):
             "inject_failure_rate", TEST_INJECT_RETRYABLE_FAILURES
         )
         self._tmpdir = mkdtemp(dir=tmproot, prefix="metaflow.s3.")
+        self._encryption = encryption
 
     def __enter__(self) -> "S3":
         return self
@@ -739,6 +759,7 @@ class S3(object):
                 "metadata": resp["Metadata"],
                 "size": resp["ContentLength"],
                 "last_modified": get_timestamp(resp["LastModified"]),
+                "encryption": resp["ServerSideEncryption"],
             }
 
         info_results = None
@@ -758,6 +779,7 @@ class S3(object):
                 content_type=info_results["content_type"],
                 metadata=info_results["metadata"],
                 last_modified=info_results["last_modified"],
+                encryption=info_results["encryption"],
             )
         return S3Object(self._s3root, url, None)
 
@@ -811,7 +833,9 @@ class S3(object):
                     else:
                         yield self._s3root, s3url, None, info["size"], info[
                             "content_type"
-                        ], info["metadata"], None, info["last_modified"]
+                        ], info["metadata"], None, info["last_modified"], info[
+                            "encryption"
+                        ]
                 else:
                     # This should not happen; we should always get a response
                     # even if it contains an error inside it
@@ -886,6 +910,7 @@ class S3(object):
             if return_info:
                 return {
                     "content_type": resp["ContentType"],
+                    "encryption": resp["ServerSideEncryption"],
                     "metadata": resp["Metadata"],
                     "range_result": range_result,
                     "last_modified": get_timestamp(resp["LastModified"]),
@@ -906,6 +931,7 @@ class S3(object):
                 url,
                 path,
                 content_type=addl_info["content_type"],
+                encryption=addl_info["encryption"],
                 metadata=addl_info["metadata"],
                 range_info=addl_info["range_result"],
                 last_modified=addl_info["last_modified"],
@@ -967,13 +993,15 @@ class S3(object):
                                 - range_info["start"]
                                 + 1,
                             )
-                        yield self._s3root, s3url, os.path.join(
-                            self._tmpdir, fname
-                        ), None, info["content_type"], info[
-                            "metadata"
-                        ], range_info, info[
-                            "last_modified"
-                        ]
+                            yield self._s3root, s3url, os.path.join(
+                                self._tmpdir, fname
+                            ), None, info["content_type"], info[
+                                "metadata"
+                            ], range_info, info[
+                                "last_modified"
+                            ], info[
+                                "encryption"
+                            ]
                     else:
                         yield self._s3root, s3prefix, None
                 else:
@@ -1033,6 +1061,8 @@ class S3(object):
                         self._tmpdir, fname
                     ), None, info["content_type"], info["metadata"], range_info, info[
                         "last_modified"
+                    ], info[
+                        "encryption"
                     ]
                 else:
                     yield s3prefix, s3url, os.path.join(self._tmpdir, fname)
@@ -1120,7 +1150,7 @@ class S3(object):
         url = self._url(key)
         src = urlparse(url)
         extra_args = None
-        if content_type or metadata:
+        if content_type or metadata or self._encryption:
             extra_args = {}
             if content_type:
                 extra_args["ContentType"] = content_type
@@ -1128,6 +1158,8 @@ class S3(object):
                 extra_args["Metadata"] = {
                     "metaflow-user-attributes": json.dumps(metadata)
                 }
+            if self._encryption:
+                extra_args["ServerSideEncryption"] = self._encryption
 
         def _upload(s3, _):
             # We make sure we are at the beginning in case we are retrying
@@ -1200,6 +1232,8 @@ class S3(object):
                     store_info["metadata"] = {
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
+                if self._encryption:
+                    store_info["encryption"] = self._encryption
                 if isinstance(obj, (RawIOBase, BufferedIOBase)):
                     if not obj.readable() or not obj.seekable():
                         raise MetaflowS3InvalidObject(
@@ -1272,6 +1306,8 @@ class S3(object):
                     store_info["metadata"] = {
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
+                if self._encryption:
+                    store_info["encryption"] = self._encryption
                 if not os.path.exists(path):
                     raise MetaflowS3NotFound("Local file not found: %s" % path)
                 yield path, self._url(key), store_info

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -759,7 +759,7 @@ class S3(object):
                 "metadata": resp["Metadata"],
                 "size": resp["ContentLength"],
                 "last_modified": get_timestamp(resp["LastModified"]),
-                "encryption": resp["ServerSideEncryption"],
+                "encryption": resp.get("ServerSideEncryption"),
             }
 
         info_results = None
@@ -910,7 +910,12 @@ class S3(object):
             if return_info:
                 return {
                     "content_type": resp["ContentType"],
-                    "encryption": resp["ServerSideEncryption"],
+                    # Since Metaflow can also use S3-compatible storage like MinIO,
+                    # there maybe some keys missing in the responses given by different S3-compatible object stores.
+                    # MinIO is generally accessed via HTTPS, and so it's encrpytion scheme is
+                    # TLS/SSL. This is why the `ServerSideEncryption` key is not present
+                    # in the response from MinIO.
+                    "encryption": resp.get("ServerSideEncryption"),
                     "metadata": resp["Metadata"],
                     "range_result": range_result,
                     "last_modified": get_timestamp(resp["LastModified"]),

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -63,6 +63,7 @@ class S3Url(object):
         local,
         prefix,
         content_type=None,
+        encryption=None,
         metadata=None,
         range=None,
         idx=None,
@@ -77,6 +78,7 @@ class S3Url(object):
         self.metadata = metadata
         self.range = range
         self.idx = idx
+        self.encryption = encryption
 
     def __str__(self):
         return self.url
@@ -171,6 +173,7 @@ def worker(result_file_name, queue, mode, s3config):
                 "error": None,
                 "size": head["ContentLength"],
                 "content_type": head["ContentType"],
+                "encryption": head["ServerSideEncryption"],
                 "metadata": head["Metadata"],
                 "last_modified": get_timestamp(head["LastModified"]),
             }
@@ -276,6 +279,8 @@ def worker(result_file_name, queue, mode, s3config):
                                 args["content_type"] = resp["ContentType"]
                             if resp["Metadata"] is not None:
                                 args["metadata"] = resp["Metadata"]
+                            if resp["ServerSideEncryption"] is not None:
+                                args["encryption"] = resp["ServerSideEncryption"]
                             if resp["LastModified"]:
                                 args["last_modified"] = get_timestamp(
                                     resp["LastModified"]
@@ -299,12 +304,14 @@ def worker(result_file_name, queue, mode, s3config):
                         do_upload = True
                     if do_upload:
                         extra = None
-                        if url.content_type or url.metadata:
+                        if url.content_type or url.metadata or url.encryption:
                             extra = {}
                             if url.content_type:
                                 extra["ContentType"] = url.content_type
                             if url.metadata is not None:
                                 extra["Metadata"] = url.metadata
+                            if url.encryption is not None:
+                                extra["ServerSideEncryption"] = url.encryption
                         try:
                             s3.upload_file(
                                 url.local, url.bucket, url.path, ExtraArgs=extra
@@ -461,6 +468,7 @@ class S3Ops(object):
                             prefix=url.prefix,
                             content_type=head["ContentType"],
                             metadata=head["Metadata"],
+                            encryption=head["ServerSideEncryption"],
                             range=url.range,
                         ),
                         head["ContentLength"],
@@ -578,7 +586,7 @@ def verify_results(urls, verbose=False):
             raise
         if expected != got:
             exit(ERROR_VERIFY_FAILED, url)
-        if url.content_type or url.metadata:
+        if url.content_type or url.metadata or url.encryption:
             # Verify that we also have a metadata file present
             try:
                 os.stat("%s_meta" % url.local)
@@ -838,11 +846,12 @@ def put(
                 url = r["url"]
                 content_type = r.get("content_type", None)
                 metadata = r.get("metadata", None)
+                encryption = r.get("encryption", None)
                 if not os.path.exists(local):
                     exit(ERROR_LOCAL_FILE_NOT_FOUND, local)
-                yield input_line_idx, local, url, content_type, metadata
+                yield input_line_idx, local, url, content_type, metadata, encryption
 
-    def _make_url(idx, local, user_url, content_type, metadata):
+    def _make_url(idx, local, user_url, content_type, metadata, encryption):
         src = urlparse(user_url)
         url = S3Url(
             url=user_url,
@@ -853,6 +862,7 @@ def put(
             content_type=content_type,
             metadata=metadata,
             idx=idx,
+            encryption=encryption,
         )
         if src.scheme != "s3":
             exit(ERROR_INVALID_URL, url)
@@ -896,6 +906,7 @@ def put(
                         "local": url.local,
                         "content_type": url.content_type,
                         "metadata": url.metadata,
+                        "encryption": url.encryption,
                     }
                 )
                 + "\n"

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -173,7 +173,7 @@ def worker(result_file_name, queue, mode, s3config):
                 "error": None,
                 "size": head["ContentLength"],
                 "content_type": head["ContentType"],
-                "encryption": head["ServerSideEncryption"],
+                "encryption": head.get("ServerSideEncryption"),
                 "metadata": head["Metadata"],
                 "last_modified": get_timestamp(head["LastModified"]),
             }
@@ -468,7 +468,7 @@ class S3Ops(object):
                             prefix=url.prefix,
                             content_type=head["ContentType"],
                             metadata=head["Metadata"],
-                            encryption=head["ServerSideEncryption"],
+                            encryption=head.get("ServerSideEncryption"),
                             range=url.range,
                         ),
                         head["ContentLength"],

--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -42,7 +42,20 @@ BIND_RETRY = 0
 
 
 class Client(object):
-    def __init__(self, python_executable, pythonpath, max_pickle_version, config_dir):
+    def __init__(
+        self, modules, python_executable, pythonpath, max_pickle_version, config_dir
+    ):
+        # Wrap with ImportError so that if users are just using the escaped module
+        # as optional, the typical logic of catching ImportError works properly
+        try:
+            self.inner_init(
+                python_executable, pythonpath, max_pickle_version, config_dir
+            )
+        except Exception as e:
+            # Typically it's one override per config so we just use the first one.
+            raise ImportError("Error loading module: %s" % str(e), name=modules[0])
+
+    def inner_init(self, python_executable, pythonpath, max_pickle_version, config_dir):
         # Make sure to init these variables (used in __del__) early on in case we
         # have an exception
         self._poller = None

--- a/metaflow/plugins/env_escape/client_modules.py
+++ b/metaflow/plugins/env_escape/client_modules.py
@@ -150,6 +150,7 @@ class ModuleImporter(object):
             max_pickle_version = min(self._max_pickle_version, pickle.HIGHEST_PROTOCOL)
 
             self._client = Client(
+                self._module_prefixes,
                 self._python_executable,
                 self._pythonpath,
                 max_pickle_version,

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -368,7 +368,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
             if trigger["fq_name"].count(".") == 0:
                 # fully qualified name is just the flow name
                 trigger["flow"] = trigger["fq_name"]
-            elif trigger["fq_name"].count(".") in (2, 3):
+            elif trigger["fq_name"].count(".") >= 2:
                 # fully qualified name is of the format - project.branch.flow_name
                 trigger["project"], tail = trigger["fq_name"].split(".", maxsplit=1)
                 trigger["branch"], trigger["flow"] = tail.rsplit(".", maxsplit=1)

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -27,7 +27,6 @@ from metaflow.metaflow_config import (
     DEFAULT_METADATA,
     DEFAULT_SECRETS_BACKEND_TYPE,
     KUBERNETES_FETCH_EC2_METADATA,
-    KUBERNETES_LABELS,
     KUBERNETES_SANDBOX_INIT_SCRIPT,
     S3_ENDPOINT_URL,
     SERVICE_HEADERS,
@@ -201,7 +200,7 @@ class Kubernetes(object):
                 retries=0,
                 step_name=step_name,
                 tolerations=tolerations,
-                labels=self._get_labels(labels),
+                labels=labels,
                 use_tmpfs=use_tmpfs,
                 tmpfs_tempdir=tmpfs_tempdir,
                 tmpfs_size=tmpfs_size,
@@ -307,8 +306,6 @@ class Kubernetes(object):
             .annotation("metaflow/step_name", step_name)
             .annotation("metaflow/task_id", task_id)
             .annotation("metaflow/attempt", attempt)
-            .label("app.kubernetes.io/name", "metaflow-task")
-            .label("app.kubernetes.io/part-of", "metaflow")
         )
 
         return job.create()
@@ -405,46 +402,6 @@ class Kubernetes(object):
             "stderr",
             job_id=self._job.id,
         )
-
-    @staticmethod
-    def _get_labels(extra_labels=None):
-        if extra_labels is None:
-            extra_labels = {}
-        env_labels = KUBERNETES_LABELS.split(",") if KUBERNETES_LABELS else []
-        env_labels = parse_kube_keyvalue_list(env_labels, False)
-        labels = {**env_labels, **extra_labels}
-        validate_kube_labels(labels)
-        return labels
-
-
-def validate_kube_labels(
-    labels: Optional[Dict[str, Optional[str]]],
-) -> bool:
-    """Validate label values.
-
-    This validates the kubernetes label values.  It does not validate the keys.
-    Ideally, keys should be static and also the validation rules for keys are
-    more complex than those for values.  For full validation rules, see:
-
-    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
-    """
-
-    def validate_label(s: Optional[str]):
-        regex_match = r"^(([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9])?$"
-        if not s:
-            # allow empty label
-            return True
-        if not re.search(regex_match, s):
-            raise KubernetesException(
-                'Invalid value: "%s"\n'
-                "A valid label must be an empty string or one that\n"
-                "  - Consist of alphanumeric, '-', '_' or '.' characters\n"
-                "  - Begins and ends with an alphanumeric character\n"
-                "  - Is at most 63 characters" % s
-            )
-        return True
-
-    return all([validate_label(v) for v in labels.values()]) if labels else True
 
 
 def parse_kube_keyvalue_list(items: List[str], requires_both: bool = True):

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -32,6 +32,7 @@ from metaflow.metaflow_config import (
     S3_ENDPOINT_URL,
     SERVICE_HEADERS,
     SERVICE_INTERNAL_URL,
+    S3_SERVER_SIDE_ENCRYPTION,
 )
 from metaflow.mflog import (
     BASH_SAVE_LOGS,
@@ -257,6 +258,11 @@ class Kubernetes(object):
             # pod; this happens when METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set (
             # see get_datastore_root_from_config in datastore/local.py).
         )
+
+        if S3_SERVER_SIDE_ENCRYPTION is not None:
+            job.environment_variable(
+                "METAFLOW_S3_SERVER_SIDE_ENCRYPTION", S3_SERVER_SIDE_ENCRYPTION
+            )
 
         # Set environment variables to support metaflow.integrations.ArgoEvent
         job.environment_variable(

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -111,6 +111,12 @@ def kubernetes():
     type=JSONTypeClass(),
     multiple=False,
 )
+@click.option(
+    "--annotations",
+    default=None,
+    type=JSONTypeClass(),
+    multiple=False,
+)
 @click.pass_context
 def step(
     ctx,
@@ -137,6 +143,7 @@ def step(
     persistent_volume_claims=None,
     tolerations=None,
     labels=None,
+    annotations=None,
     **kwargs
 ):
     def echo(msg, stream="stderr", job_id=None, **kwargs):
@@ -252,6 +259,7 @@ def step(
                 persistent_volume_claims=persistent_volume_claims,
                 tolerations=tolerations,
                 labels=labels,
+                annotations=annotations,
             )
     except Exception as e:
         traceback.print_exc(chain=False)

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -7,7 +7,7 @@ from metaflow import JSONTypeClass, util
 from metaflow._vendor import click
 from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY, CommandException
 from metaflow.metadata.util import sync_local_metadata_from_datastore
-from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, KUBERNETES_LABELS
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
 from metaflow.mflog import TASK_LOG_SOURCE
 
 from .kubernetes import Kubernetes, KubernetesKilledException, parse_kube_keyvalue_list
@@ -105,6 +105,12 @@ def kubernetes():
     type=JSONTypeClass(),
     multiple=False,
 )
+@click.option(
+    "--labels",
+    default=None,
+    type=JSONTypeClass(),
+    multiple=False,
+)
 @click.pass_context
 def step(
     ctx,
@@ -130,6 +136,7 @@ def step(
     run_time_limit=None,
     persistent_volume_claims=None,
     tolerations=None,
+    labels=None,
     **kwargs
 ):
     def echo(msg, stream="stderr", job_id=None, **kwargs):
@@ -244,6 +251,7 @@ def step(
                 env=env,
                 persistent_volume_claims=persistent_volume_claims,
                 tolerations=tolerations,
+                labels=labels,
             )
     except Exception as e:
         traceback.print_exc(chain=False)

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -18,6 +18,7 @@ from metaflow.metaflow_config import (
     KUBERNETES_IMAGE_PULL_POLICY,
     KUBERNETES_GPU_VENDOR,
     KUBERNETES_LABELS,
+    KUBERNETES_ANNOTATIONS,
     KUBERNETES_NAMESPACE,
     KUBERNETES_NODE_SELECTOR,
     KUBERNETES_PERSISTENT_VOLUME_CLAIMS,
@@ -71,6 +72,8 @@ class KubernetesDecorator(StepDecorator):
         Kubernetes tolerations to use when launching pod in Kubernetes.
     labels: Dict[str, str], default: METAFLOW_KUBERNETES_LABELS
         Kubernetes labels to use when launching pod in Kubernetes.
+    annotations: Dict[str, str], default: METAFLOW_KUBERNETES_ANNOTATIONS
+        Kubernetes annotations to use when launching pod in Kubernetes.
     use_tmpfs: bool, default: False
         This enables an explicit tmpfs mount for this step.
     tmpfs_tempdir: bool, default: True
@@ -102,6 +105,7 @@ class KubernetesDecorator(StepDecorator):
         "tolerations": None,  # e.g., [{"key": "arch", "operator": "Equal", "value": "amd"},
         #                              {"key": "foo", "operator": "Equal", "value": "bar"}]
         "labels": None,  # e.g. {"test-label": "value", "another-label":"value2"}
+        "annotations": None,  # e.g. {"note": "value", "another-note": "value2"}
         "use_tmpfs": None,
         "tmpfs_tempdir": True,
         "tmpfs_size": None,
@@ -182,6 +186,41 @@ class KubernetesDecorator(StepDecorator):
         }
 
         self.attributes["labels"] = {**env_labels, **deco_labels, **system_labels}
+
+        # Annotations
+        # annotation precedence (decreasing):
+        # - System annotations
+        # - Decorator annotations
+        # - Environment annotations
+        deco_annotations = {}
+        if self.attributes["annotations"] is not None:
+            deco_annotations = self.attributes["annotations"]
+
+        env_annotations = {}
+        if KUBERNETES_ANNOTATIONS:
+            env_annotations = parse_kube_keyvalue_list(
+                KUBERNETES_ANNOTATIONS.split(","), False
+            )
+
+        system_annotations = {
+            "metaflow/user": current.username,
+            "metaflow/flow_name": current.flow_name,
+        }
+
+        if current.get("project_name"):
+            system_annotations.update(
+                {
+                    "metaflow/project_name": current.project_name,
+                    "metaflow/branch_name": current.branch_name,
+                    "metaflow/project_flow_name": current.project_flow_name,
+                }
+            )
+
+        self.attributes["annotations"] = {
+            **env_annotations,
+            **deco_annotations,
+            **system_annotations,
+        }
 
         # If no docker image is explicitly specified, impute a default image.
         if not self.attributes["image"]:
@@ -307,6 +346,7 @@ class KubernetesDecorator(StepDecorator):
                 )
 
         validate_kube_labels_or_annotations(self.attributes["labels"])
+        validate_kube_labels_or_annotations(self.attributes["annotations"])
 
     def package_init(self, flow, step_name, environment):
         try:
@@ -359,7 +399,12 @@ class KubernetesDecorator(StepDecorator):
                         "=".join([key, str(val)]) if val else key
                         for key, val in v.items()
                     ]
-                elif k in ["tolerations", "persistent_volume_claims", "labels"]:
+                elif k in [
+                    "tolerations",
+                    "persistent_volume_claims",
+                    "labels",
+                    "annotations",
+                ]:
                     cli_args.command_options[k] = json.dumps(v)
                 else:
                     cli_args.command_options[k] = v

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -306,7 +306,7 @@ class KubernetesDecorator(StepDecorator):
                     )
                 )
 
-        validate_kube_labels(self.attributes["labels"])
+        validate_kube_labels_or_annotations(self.attributes["labels"])
 
     def package_init(self, flow, step_name, environment):
         try:
@@ -472,7 +472,7 @@ class KubernetesDecorator(StepDecorator):
             )[0]
 
 
-def validate_kube_labels(
+def validate_kube_labels_or_annotations(
     labels: Optional[Dict[str, Optional[str]]],
 ) -> bool:
     """Validate label values.

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -514,30 +514,24 @@ class RunningJob(object):
 
     @property
     def is_done(self):
-        # Check if the job is done. As a side effect, also refreshes self._job and
+        # Check if the container is done. As a side effect, also refreshes self._job and
         # self._pod with the latest state
         def done():
-            # Either the job succeeds or fails naturally or else we may have
+            # Either the container succeeds or fails naturally or else we may have
             # forced the pod termination causing the job to still be in an
             # active state but for all intents and purposes dead to us.
             return (
                 bool(self._job["status"].get("succeeded"))
                 or bool(self._job["status"].get("failed"))
+                or self._are_pod_containers_done
                 or (self._job["spec"]["parallelism"] == 0)
             )
 
         if not done():
             # If not done, fetch newer status
             self._job = self._fetch_job()
-        if done():
-            return True
-        else:
-            # It is possible for the job metadata to not be updated yet, but the
-            # pod may have already succeeded or failed.
             self._pod = self._fetch_pod()
-            return self._pod and (
-                self._pod.get("status", {}).get("phase") in ("Succeeded", "Failed")
-            )
+        return done()
 
     @property
     def status(self):
@@ -577,28 +571,102 @@ class RunningJob(object):
 
     @property
     def has_succeeded(self):
-        # Job is in a terminal state and the status is marked as succeeded
-        return self.is_done and (
-            bool(self._job["status"].get("succeeded"))
-            or (self._pod.get("status", {}).get("phase") == "Succeeded")
-        )
+        # The tasks container is in a terminal state and the status is marked as succeeded
+        return self.is_done and self._have_containers_succeeded
 
     @property
     def has_failed(self):
-        # Job is in a terminal state and either the status is marked as failed
-        # or the Job is not allowed to launch any more pods
-        return self.is_done and (
+        # Either the container is marked as failed or the Job is not allowed to
+        # any more pods
+        retval = self.is_done and (
             bool(self._job["status"].get("failed"))
+            or self._has_any_container_failed
             or (self._job["spec"]["parallelism"] == 0)
-            or (self._pod.get("status", {}).get("phase") == "Failed")
         )
+        return retval
+
+    @property
+    def _have_containers_succeeded(self):
+        container_statuses = self._pod.get("status", {}).get("container_statuses", [])
+        if not container_statuses:
+            return False
+
+        for cstatus in container_statuses:
+            # If the terminated field is not set, the pod is still running.
+            terminated = cstatus.get("state", {}).get("terminated", {})
+            if not terminated:
+                return False
+
+            # If the terminated field is set but the `finished_at` field is not set,
+            # the pod is still considered as running.
+            if not terminated.get("finished_at"):
+                return False
+
+            # If finished_at is set AND reason is Completed
+            if terminated.get("reason", "").lower() != "completed":
+                return False
+
+        return True
+
+    @property
+    def _has_any_container_failed(self):
+        container_statuses = self._pod.get("status", {}).get("container_statuses", [])
+        if not container_statuses:
+            return False
+
+        for cstatus in container_statuses:
+            # If the terminated field is not set, the pod is still running. Too early
+            # to determine if any container failed.
+            terminated = cstatus.get("state", {}).get("terminated", {})
+            if not terminated:
+                return False
+
+            # If the terminated field is set but the `finished_at` field is not set,
+            # the pod is still considered as running. Too early to determine if any
+            # container failed.
+            if not terminated.get("finished_at"):
+                return False
+
+            # If finished_at is set AND reason is Error, it means that the
+            # container failed.
+            if terminated.get("reason", "").lower() == "error":
+                return True
+
+        # If none of the containers are marked as failed, the pod is not
+        # considered failed.
+        return False
+
+    @property
+    def _are_pod_containers_done(self):
+        # All containers in the pod have a containerStatus that has a
+        # finishedAt set.
+        container_statuses = self._pod.get("status", {}).get("container_statuses", [])
+        if not container_statuses:
+            return False
+
+        for cstatus in container_statuses:
+            # If the terminated field is not set, the pod is still running. Too early
+            # to determine if any container failed.
+            terminated = cstatus.get("state", {}).get("terminated", {})
+            if not terminated:
+                return False
+
+            # If the terminated field is set but the `finished_at` field is not set,
+            # the pod is still considered as running.
+            if not terminated.get("finished_at"):
+                return False
+
+        # If we got until here, the containers were marked terminated and their
+        # finishedAt was set.
+        return True
 
     @property
     def is_running(self):
-        # Returns true if the pod is running.
-        return not self.is_done and (
-            self._pod.get("status", {}).get("phase") == "Running"
-        )
+        # Returns true if the container is running.
+        if self.is_done:
+            return False
+
+        return not self._are_pod_containers_done
 
     @property
     def is_waiting(self):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "2.9.4"
+version = "2.9.5"
 
 setup(
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "2.9.6"
+version = "2.9.7"
 
 setup(
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "2.9.5"
+version = "2.9.6"
 
 setup(
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "2.9.3"
+version = "2.9.4"
 
 setup(
     include_package_data=True,

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -41,7 +41,12 @@ def s3_get_object_from_url_range(url, range_info):
 
 
 def assert_results(
-    s3objs, expected, info_should_be_empty=False, info_only=False, ranges_fetched=None
+    s3objs,
+    expected,
+    info_should_be_empty=False,
+    info_only=False,
+    ranges_fetched=None,
+    encryption=None,
 ):
     # did we receive all expected objects and nothing else?
     if info_only:
@@ -144,6 +149,9 @@ def assert_results(
                     assert not extra_keys, "Additional metadata present %s" % str(
                         extra_keys
                     )
+                # if encryption was used
+                if encryption:
+                    assert s3obj.encryption == encryption
 
 
 def shuffle(objs):
@@ -805,99 +813,133 @@ def test_put_exceptions(inject_failure_rate):
             s3.put_many([("foo", "bar")])
 
 
-@pytest.mark.parametrize("inject_failure_rate", [0, 10, 50, 90])
+@pytest.fixture
+def s3_server_side_encryption():
+    return "AES256"
+
+
+@pytest.mark.parametrize("inject_failure_rate", [0])
 @pytest.mark.parametrize(
     argnames=["s3root", "objs", "expected"], **s3_data.pytest_put_strings_case()
 )
-def test_put_many(inject_failure_rate, s3root, objs, expected):
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        s3urls = s3.put_many(objs)
-        assert list(dict(s3urls)) == list(dict(objs))
-        # results must be in the same order as the keys requested
-        for i in range(len(s3urls)):
-            assert objs[i][0] == s3urls[i][0]
-    with S3(inject_failure_rate=inject_failure_rate) as s3:
-        s3objs = s3.get_many(dict(s3urls).values())
-        assert_results(s3objs, expected)
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        s3objs = s3.get_many(list(dict(objs)))
-        assert {s3obj.key for s3obj in s3objs} == {key for key, _ in objs}
+def test_put_many(
+    inject_failure_rate, s3root, objs, expected, s3_server_side_encryption
+):
+    encryption_settings = [None, s3_server_side_encryption]
+    for setting in encryption_settings:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            s3urls = s3.put_many(objs)
+            assert list(dict(s3urls)) == list(dict(objs))
+            # results must be in the same order as the keys requested
+            for i in range(len(s3urls)):
+                assert objs[i][0] == s3urls[i][0]
+        with S3(inject_failure_rate=inject_failure_rate, encryption=setting) as s3:
+            s3objs = s3.get_many(dict(s3urls).values())
+            assert_results(s3objs, expected)
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            s3objs = s3.get_many(list(dict(objs)))
+            assert {s3obj.key for s3obj in s3objs} == {key for key, _ in objs}
 
-    # upload shuffled objs with overwrite disabled
-    shuffled_objs = deranged_shuffle(objs)
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        overwrite_disabled_s3urls = s3.put_many(shuffled_objs, overwrite=False)
-        assert len(overwrite_disabled_s3urls) == 0
-    with S3(inject_failure_rate=inject_failure_rate) as s3:
-        s3objs = s3.get_many(dict(s3urls).values())
-        assert_results(s3objs, expected)
+        # upload shuffled objs with overwrite disabled
+        shuffled_objs = deranged_shuffle(objs)
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            overwrite_disabled_s3urls = s3.put_many(shuffled_objs, overwrite=False)
+            assert len(overwrite_disabled_s3urls) == 0
+        with S3(inject_failure_rate=inject_failure_rate, encryption=setting) as s3:
+            s3objs = s3.get_many(dict(s3urls).values())
+            assert_results(s3objs, expected)
 
 
 @pytest.mark.parametrize(
     argnames=["s3root", "objs", "expected"], **s3_data.pytest_put_strings_case()
 )
-def test_put_one(s3root, objs, expected):
-    with S3(s3root=s3root) as s3:
-        for key, obj in objs:
-            s3url = s3.put(key, obj)
-            assert s3url in expected
-            s3obj = s3.get(key)
-            assert s3obj.key == key
-            assert_results([s3obj], {s3url: expected[s3url]})
-            assert s3obj.blob == to_bytes(obj)
-            # put with overwrite disabled
-            s3url = s3.put(key, "random_value", overwrite=False)
-            assert s3url in expected
-            s3obj = s3.get(key)
-            assert s3obj.key == key
-            assert_results([s3obj], {s3url: expected[s3url]})
-            assert s3obj.blob == to_bytes(obj)
+def test_put_one(s3root, objs, expected, s3_server_side_encryption):
+    encryption_settings = [None, s3_server_side_encryption]
+    for setting in encryption_settings:
+        with S3(s3root=s3root, encryption=setting) as s3:
+            for key, obj in objs:
+                s3url = s3.put(key, obj)
+                assert s3url in expected
+                s3obj = s3.get(key)
+                assert s3obj.key == key
+                assert_results([s3obj], {s3url: expected[s3url]}, encryption=setting)
+                assert s3obj.blob == to_bytes(obj)
+                # put with overwrite disabled
+                s3url = s3.put(key, "random_value", overwrite=False)
+                assert s3url in expected
+                s3obj = s3.get(key)
+                assert s3obj.key == key
+                assert_results([s3obj], {s3url: expected[s3url]}, encryption=setting)
+                assert s3obj.blob == to_bytes(obj)
 
 
 @pytest.mark.parametrize("inject_failure_rate", [0, 10, 50, 90])
 @pytest.mark.parametrize(
     argnames=["s3root", "blobs", "expected"], **s3_data.pytest_put_blobs_case()
 )
-def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected):
+def test_put_files(
+    tempdir, inject_failure_rate, s3root, blobs, expected, s3_server_side_encryption
+):
     def _files(blobs):
         for blob in blobs:
             key = getattr(blob, "key", blob[0])
             data = getattr(blob, "value", blob[1])
             content_type = getattr(blob, "content_type", None)
             metadata = getattr(blob, "metadata", None)
+            encryption = getattr(blob, "encryption", None)
             path = os.path.join(tempdir, key)
             with open(path, "wb") as f:
                 f.write(data)
             yield S3PutObject(
-                key=key, value=path, content_type=content_type, metadata=metadata
+                key=key,
+                value=path,
+                content_type=content_type,
+                metadata=metadata,
+                encryption=encryption,
             )
 
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        s3urls = s3.put_files(_files(blobs))
-        assert list(dict(s3urls)) == list(dict(blobs))
+    encryption_settings = [None, s3_server_side_encryption]
+    for setting in encryption_settings:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            s3urls = s3.put_files(_files(blobs))
+            assert list(dict(s3urls)) == list(dict(blobs))
 
-    with S3(inject_failure_rate=inject_failure_rate) as s3:
-        # get urls
-        s3objs = s3.get_many(dict(s3urls).values())
-        assert_results(s3objs, expected)
+        with S3(inject_failure_rate=inject_failure_rate, encryption=setting) as s3:
+            # get urls
+            s3objs = s3.get_many(dict(s3urls).values())
+            assert_results(s3objs, expected, encryption=setting)
 
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        # get keys
-        s3objs = s3.get_many(key for key, blob in blobs)
-        assert {s3obj.key for s3obj in s3objs} == {key for key, _ in blobs}
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            # get keys
+            s3objs = s3.get_many(key for key, blob in blobs)
+            assert {s3obj.key for s3obj in s3objs} == {key for key, _ in blobs}
 
-    # upload shuffled blobs with overwrite disabled
-    shuffled_blobs = blobs[:]
-    shuffle(shuffled_blobs)
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        overwrite_disabled_s3urls = s3.put_files(
-            _files(shuffled_blobs), overwrite=False
-        )
-        assert len(overwrite_disabled_s3urls) == 0
+        # upload shuffled blobs with overwrite disabled
+        shuffled_blobs = blobs[:]
+        shuffle(shuffled_blobs)
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            overwrite_disabled_s3urls = s3.put_files(
+                _files(shuffled_blobs), overwrite=False
+            )
+            assert len(overwrite_disabled_s3urls) == 0
 
-    with S3(inject_failure_rate=inject_failure_rate) as s3:
-        s3objs = s3.get_many(dict(s3urls).values())
-        assert_results(s3objs, expected)
-    with S3(s3root=s3root, inject_failure_rate=inject_failure_rate) as s3:
-        s3objs = s3.get_many(key for key, blob in shuffled_blobs)
-        assert {s3obj.key for s3obj in s3objs} == {key for key, _ in shuffled_blobs}
+        with S3(inject_failure_rate=inject_failure_rate, encryption=setting) as s3:
+            s3objs = s3.get_many(dict(s3urls).values())
+            assert_results(s3objs, expected, encryption=setting)
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, encryption=setting
+        ) as s3:
+            s3objs = s3.get_many(key for key, blob in shuffled_blobs)
+            assert {s3obj.key for s3obj in s3objs} == {key for key, _ in shuffled_blobs}

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -5,7 +5,9 @@ from metaflow.plugins.kubernetes.kubernetes import (
     parse_kube_keyvalue_list,
 )
 
-from metaflow.plugins.kubernetes.kubernetes_decorator import validate_kube_labels
+from metaflow.plugins.kubernetes.kubernetes_decorator import (
+    validate_kube_labels_or_annotations,
+)
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -2,9 +2,10 @@ import pytest
 
 from metaflow.plugins.kubernetes.kubernetes import (
     KubernetesException,
-    validate_kube_labels,
     parse_kube_keyvalue_list,
 )
+
+from metaflow.plugins.kubernetes.kubernetes_decorator import validate_kube_labels
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As part of the previous discussions, I mentioned that there was a need to start refactoring how the Kubernetes labels are being handled, moving much of the logic into the decorator instead of spreading logic across `argo_workflows.py` and `kubernetes.py`

As the annotations is going to follow the same patterns, this is a good opportunity to rework those at the same time to be handled inside the Kubernetes decorator as much as possible.

This PR:
- branches off your `annotations_dev`
- merged https://github.com/Netflix/metaflow/pull/1471 on top of it (branched later, hence some of the unrelated commits in it)
- refactored the custom annotations into the Kubernetes decorator.